### PR TITLE
[CLN] Move BASE_URL to config file | GEN-11549

### DIFF
--- a/liquid_earth_api/api/le_api.py
+++ b/liquid_earth_api/api/le_api.py
@@ -23,6 +23,10 @@ def set_token(token: str):
 
 def upload_mesh_to_existing_space(space_name: str, data: subsurface.UnstructuredData, file_name: str,
                                   token: str, grab_link: bool = True) -> Union[bool, dict]:
+    # * Make sure file name does not contain .le
+    if file_name.endswith('.le'):
+        file_name = file_name[:-3]
+    
     # * grab space
     available_projects = get_available_projects(token)
     # ? which type is actually returned here?a
@@ -73,6 +77,7 @@ def post_add_data_to_space(unstructured_data: subsurface.UnstructuredData, post_
 
 
 def _upload_mesh_common(data, file_name, found_project, grab_link, token):
+    
     # * upload data
     post_data = AddDataPostData(
         spaceId=found_project["SpaceId"],

--- a/liquid_earth_api/config.py
+++ b/liquid_earth_api/config.py
@@ -1,0 +1,15 @@
+import socket
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+backend_override = os.environ.get("BACKEND_OVERRIDE")
+# If backend_override is local host, use the socket.gethostname() to get the local host name
+if "localhost" in backend_override:
+    port = backend_override.split(":")[-1].split("/")[0]
+    backend_override = f"http://{socket.gethostname()}.local:{port}/api"
+
+LE_APIM = f"https://liquidearthapim-prod001.azure-api.net/python/"
+BASE_URL = LE_APIM if backend_override is None else backend_override

--- a/liquid_earth_api/modules/blob_client/blob_interface.py
+++ b/liquid_earth_api/modules/blob_client/blob_interface.py
@@ -21,5 +21,3 @@ def push_unstructured_data(unstructured_data: subsurface.UnstructuredData, sas_d
     except Exception as e:
         print(f"Error uploading files: {e}")
         raise ValueError(f"Error uploading files: {e}")
-
-

--- a/liquid_earth_api/modules/rest_client/_links.py
+++ b/liquid_earth_api/modules/rest_client/_links.py
@@ -2,8 +2,8 @@ from dataclasses import asdict
 
 import requests
 
-from liquid_earth_api.modules.rest_client._utils import BASE_URL
 from liquid_earth_api.data.schemas import AddDataPostData
+from liquid_earth_api.config import BASE_URL
 
 
 def get_deep_link(post_data: AddDataPostData, token: str):

--- a/liquid_earth_api/modules/rest_client/_utils.py
+++ b/liquid_earth_api/modules/rest_client/_utils.py
@@ -5,19 +5,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-def make_url(endpoint: str) -> str:
-    return f"{BASE_URL}/{endpoint}"
-
-backend_override = os.environ.get("BACKEND_OVERRIDE")
-# If backend_override is local host, use the socket.gethostname() to get the local host name
-if "localhost" in backend_override:
-    port = backend_override.split(":")[-1].split("/")[0]
-    backend_override = f"http://{socket.gethostname()}.local:{port}/api"
-
-
-BASE_URL =  f"https://apim-liquidearth.azure-api.net/python" if backend_override is None else backend_override
-    
-
 
 def handle_response(response) -> any:
     """ Helper function to handle common response logic. """

--- a/liquid_earth_api/modules/rest_client/rest_interface.py
+++ b/liquid_earth_api/modules/rest_client/rest_interface.py
@@ -1,7 +1,8 @@
-from liquid_earth_api.modules.rest_client._utils import BASE_URL, handle_response
+from liquid_earth_api.modules.rest_client._utils import handle_response
 from liquid_earth_api.data.schemas import AddNewSpacePostData, AddDataPostData, DeleteSpacePostData
 import requests
 from dataclasses import asdict
+from liquid_earth_api.config import BASE_URL
 
 
 def get_deep_link(post_data: AddDataPostData, token: str) -> dict:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+core
+gempy

--- a/tests/test_subsurface_link.py
+++ b/tests/test_subsurface_link.py
@@ -11,7 +11,6 @@ user_token = os.environ.get("LIQUID_EARTH_API_TOKEN")
 
 space_name = "Ideon demo space"
 
-pytestmark = pytest.mark.skip(reason="not read")
 
 def test_dxf_mesh_to_existing_space():
     import subsurface as ss
@@ -33,15 +32,14 @@ def test_dxf_mesh_to_existing_space():
     if False:
         ss.visualization.pv_plot([s], image_2d=False)
 
-    link = le_api.upload_mesh_to_existing_space(
-        # space_name="Demo (exported from geoh5)",
-        space_name="Shared Example: MX",
-        data=unstruct,
-        file_name="dxf",
-        token=user_token,
-        grab_link=False
-    )
-    pass
+    if True: 
+        link = le_api.upload_mesh_to_existing_space(
+            space_name="[TEMP] DXF From SDK",
+            data=unstruct,
+            file_name="dxf",
+            token=user_token,
+            grab_link=False
+        )
 
 
 def test_mx_mesh_to_existing_space():
@@ -53,13 +51,9 @@ def test_mx_mesh_to_existing_space():
     s = ss.visualization.to_pyvista_mesh(ts)
     ss.visualization.pv_plot([s], image_2d=True)
 
-    new_file = open(f"mx.le", "wb")
-    new_file.write(unstruct.to_binary())
-
     link = le_api.upload_mesh_to_existing_space(
-        space_name="Shared Example: MX",
+        space_name="[TEMP] MX From SDK",
         data=unstruct,
-        file_name="mx_file.le",
+        file_name="mx_file",
         token=user_token
     )
-    pass

--- a/tests/test_subsurface_link.py
+++ b/tests/test_subsurface_link.py
@@ -9,8 +9,7 @@ load_dotenv()
 
 user_token = os.environ.get("LIQUID_EARTH_API_TOKEN")
 
-space_name = "Ideon demo space"
-
+pytestmark = pytest.mark.core
 
 def test_dxf_mesh_to_existing_space():
     import subsurface as ss


### PR DESCRIPTION
[CLN] Move BASE_URL to config file

[CLN]

[CLN] Update tests and handle file extension in API

Removed unused code and adjusted test cases for mesh uploads with updated temporary space names. Ensured the API function `upload_mesh_to_existing_space` handles `.le` file extensions correctly by stripping them.

[CLN] Update pytest configuration and mark tests for core